### PR TITLE
[Under Review] feat: implement bulk actions for datatable

### DIFF
--- a/Examples/UserDatatable.php
+++ b/Examples/UserDatatable.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Datatables;
+
+use App\Models\User;
+use Redot\Datatables\Actions\Action;
+use Redot\Datatables\Actions\BulkAction;
+use Redot\Datatables\Columns\TextColumn;
+use Redot\Datatables\Columns\DateColumn;
+use Redot\Datatables\Columns\BadgeColumn;
+use Redot\Datatables\Datatable;
+
+class UserDatatable extends Datatable
+{
+    protected string $model = User::class;
+
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')
+                ->label('Name')
+                ->searchable()
+                ->sortable(),
+
+            TextColumn::make('email')
+                ->label('Email')
+                ->searchable()
+                ->sortable(),
+
+            BadgeColumn::make('status')
+                ->label('Status')
+                ->colors([
+                    'active' => 'success',
+                    'inactive' => 'danger',
+                ]),
+
+            DateColumn::make('created_at')
+                ->label('Created At')
+                ->sortable(),
+        ];
+    }
+
+    public function actions(): array
+    {
+        return [
+            Action::view('users.show'),
+            Action::edit('users.edit'),
+            Action::delete('users.destroy'),
+        ];
+    }
+
+    public function bulkActions(): array
+    {
+        return [
+            // Basic bulk delete action
+            BulkAction::delete('users.bulk-delete')
+                ->confirmMessage('Are you sure you want to delete :count selected users?'),
+
+            // Bulk export action
+            BulkAction::export('users.bulk-export')
+                ->variant('outline-success'),
+
+            // Custom bulk action to activate users
+            BulkAction::make('Activate Users', 'fas fa-check-circle')
+                ->route('users.bulk-activate')
+                ->method('patch')
+                ->variant('outline-success')
+                ->confirmMessage('Are you sure you want to activate :count selected users?'),
+
+            // Custom bulk action to deactivate users
+            BulkAction::make('Deactivate Users', 'fas fa-ban')
+                ->route('users.bulk-deactivate')
+                ->method('patch')
+                ->variant('outline-warning')
+                ->confirmMessage('Are you sure you want to deactivate :count selected users?'),
+
+            // Bulk action with minimum selection requirement
+            BulkAction::make('Send Notifications', 'fas fa-envelope')
+                ->route('users.bulk-notify')
+                ->method('post')
+                ->variant('outline-info')
+                ->minSelection(3)
+                ->confirmMessage('Are you sure you want to send notifications to :count selected users?'),
+
+            // Bulk action with maximum selection limit
+            BulkAction::make('Assign to Project', 'fas fa-project-diagram')
+                ->route('users.bulk-assign-project')
+                ->method('post')
+                ->variant('outline-primary')
+                ->maxSelection(10)
+                ->confirmMessage('Are you sure you want to assign :count selected users to the project?'),
+
+            // Conditional bulk action
+            BulkAction::make('Archive Users', 'fas fa-archive')
+                ->route('users.bulk-archive')
+                ->method('patch')
+                ->variant('outline-secondary')
+                ->condition(fn() => auth()->user()->can('archive-users'))
+                ->confirmMessage('Are you sure you want to archive :count selected users?'),
+        ];
+    }
+} 

--- a/docs/bulk-actions.md
+++ b/docs/bulk-actions.md
@@ -1,0 +1,259 @@
+# Bulk Actions
+
+Bulk actions allow users to perform operations on multiple selected rows at once. This feature is implemented following the same patterns as individual row actions.
+
+## Basic Usage
+
+To add bulk actions to your datatable, define the `bulkActions()` method in your datatable class:
+
+```php
+use Redot\Datatables\Actions\BulkAction;
+
+public function bulkActions(): array
+{
+    return [
+        BulkAction::delete('users.bulk-delete'),
+        BulkAction::export('users.bulk-export'),
+        BulkAction::update('users.bulk-update'),
+    ];
+}
+```
+
+## Available Methods
+
+### Static Factory Methods
+
+- `BulkAction::delete()` - Creates a bulk delete action
+- `BulkAction::export()` - Creates a bulk export action  
+- `BulkAction::update()` - Creates a bulk update action
+- `BulkAction::make()` - Creates a custom bulk action
+
+### Configuration Methods
+
+#### Basic Configuration
+```php
+BulkAction::make('Custom Action', 'fas fa-icon')
+    ->label('Custom Label')           // Set action label
+    ->icon('fas fa-custom-icon')      // Set action icon
+    ->route('route.name')             // Set route
+    ->method('post')                  // Set HTTP method (get, post, put, patch, delete)
+    ->variant('outline-primary')      // Set button variant
+```
+
+#### Selection Constraints
+```php
+BulkAction::make('Send Notifications')
+    ->minSelection(3)                 // Require minimum 3 items
+    ->maxSelection(10)                // Allow maximum 10 items
+```
+
+#### Confirmation
+```php
+BulkAction::make('Delete Users')
+    ->confirmable()                   // Enable confirmation
+    ->confirmMessage('Delete :count users?') // Custom message (:count placeholder)
+```
+
+#### Visibility & Conditions
+```php
+BulkAction::make('Admin Action')
+    ->visible(true)                   // Set visibility
+    ->condition(fn() => auth()->user()->isAdmin()) // Conditional display
+```
+
+#### Additional Options
+```php
+BulkAction::make('Export')
+    ->newTab()                        // Open in new tab
+    ->parameters(['format' => 'xlsx']) // Additional route parameters
+    ->body(['extra' => 'data'])       // Extra form data
+```
+
+## Button Variants
+
+Available button variants:
+- `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `light`, `dark`
+- `outline-primary`, `outline-secondary`, etc.
+
+## Frontend Integration
+
+### Selected Items Array
+
+The selected items are automatically passed to your route handler as a `selected` array parameter:
+
+```php
+// Controller method
+public function bulkDelete(Request $request)
+{
+    $selectedIds = $request->get('selected', []);
+    
+    User::whereIn('id', $selectedIds)->delete();
+    
+    return redirect()->back()->with('success', 'Users deleted successfully');
+}
+```
+
+### JavaScript Events
+
+The bulk actions integrate with the existing JavaScript confirmation system:
+
+```javascript
+// Custom confirmation handler (optional)
+window.warnBeforeAction = function(callback, options) {
+    // Your custom confirmation logic
+    if (customConfirm(options.content)) {
+        callback();
+    }
+};
+```
+
+## UI Features
+
+### Selection UI
+- Checkbox in table header for "select all" functionality
+- Individual checkboxes for each row
+- Selection counter showing number of selected items
+- Clear selection button
+
+### Bulk Actions Bar
+- Appears when items are selected
+- Shows selection count
+- Displays bulk action buttons
+- Includes clear selection button
+
+## Complete Example
+
+```php
+<?php
+
+namespace App\Datatables;
+
+use App\Models\User;
+use Redot\Datatables\Actions\Action;
+use Redot\Datatables\Actions\BulkAction;
+use Redot\Datatables\Columns\TextColumn;
+use Redot\Datatables\Datatable;
+
+class UserDatatable extends Datatable
+{
+    protected string $model = User::class;
+
+    public function columns(): array
+    {
+        return [
+            TextColumn::make('name')->searchable()->sortable(),
+            TextColumn::make('email')->searchable()->sortable(),
+            // ... other columns
+        ];
+    }
+
+    public function actions(): array
+    {
+        return [
+            Action::view('users.show'),
+            Action::edit('users.edit'),
+            Action::delete('users.destroy'),
+        ];
+    }
+
+    public function bulkActions(): array
+    {
+        return [
+            // Basic actions
+            BulkAction::delete('users.bulk-delete')
+                ->confirmMessage('Delete :count selected users?'),
+                
+            BulkAction::export('users.bulk-export'),
+
+            // Custom actions
+            BulkAction::make('Activate', 'fas fa-check')
+                ->route('users.bulk-activate')
+                ->method('patch')
+                ->variant('outline-success'),
+
+            BulkAction::make('Send Email', 'fas fa-envelope')
+                ->route('users.bulk-email')
+                ->minSelection(2)
+                ->maxSelection(50)
+                ->confirmable(),
+
+            // Conditional action
+            BulkAction::make('Admin Action', 'fas fa-crown')
+                ->route('users.admin-action')
+                ->condition(fn() => auth()->user()->isAdmin())
+                ->variant('outline-warning'),
+        ];
+    }
+}
+```
+
+## Controller Example
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function bulkDelete(Request $request)
+    {
+        $selectedIds = $request->get('selected', []);
+        
+        if (empty($selectedIds)) {
+            return redirect()->back()->with('error', 'No users selected');
+        }
+
+        $deletedCount = User::whereIn('id', $selectedIds)->delete();
+        
+        return redirect()->back()->with('success', "Deleted {$deletedCount} users successfully");
+    }
+
+    public function bulkActivate(Request $request)
+    {
+        $selectedIds = $request->get('selected', []);
+        
+        $updatedCount = User::whereIn('id', $selectedIds)
+            ->update(['status' => 'active']);
+            
+        return redirect()->back()->with('success', "Activated {$updatedCount} users successfully");
+    }
+}
+```
+
+## Routes Example
+
+```php
+// routes/web.php
+Route::delete('users/bulk-delete', [UserController::class, 'bulkDelete'])->name('users.bulk-delete');
+Route::patch('users/bulk-activate', [UserController::class, 'bulkActivate'])->name('users.bulk-activate');
+Route::post('users/bulk-export', [UserController::class, 'bulkExport'])->name('users.bulk-export');
+```
+
+## Internationalization
+
+Bulk action labels and messages support Laravel's localization system:
+
+```php
+// lang/en/datatables.php
+'bulk_actions' => [
+    'delete' => 'Bulk Delete',
+    'export' => 'Bulk Export', 
+    'update' => 'Bulk Update',
+    'confirm' => 'Are you sure you want to perform this action on the selected items?',
+    'select_all' => 'Select All',
+    'deselect_all' => 'Deselect All',
+    'selected_count' => ':count item(s) selected',
+    'clear_selection' => 'Clear Selection',
+],
+```
+
+Use translation keys in your bulk actions:
+
+```php
+BulkAction::make(__('Custom Action'))
+    ->confirmMessage(__('Custom confirmation for :count items'))
+``` 

--- a/lang/ar/datatable.php
+++ b/lang/ar/datatable.php
@@ -41,6 +41,18 @@ return [
         'confirm' => 'هل أنت متأكد أنك تريد تنفيذ هذا الإجراء؟',
     ],
 
+    'bulk_actions' => [
+        'delete' => 'حذف جماعي',
+        'export' => 'تصدير جماعي',
+        'update' => 'تحديث جماعي',
+        'confirm' => 'هل أنت متأكد أنك تريد تنفيذ هذا الإجراء على العناصر المحددة؟',
+        'select_all' => 'تحديد الكل',
+        'deselect_all' => 'إلغاء تحديد الكل',
+        'selected_count' => ':count عنصر محدد',
+        'no_items_selected' => 'لم يتم تحديد أي عناصر',
+        'clear_selection' => 'إلغاء التحديد',
+    ],
+
     'filters' => [
         'select' => [
             'placeholder' => 'اختر خيارًا',

--- a/lang/en/datatable.php
+++ b/lang/en/datatable.php
@@ -41,6 +41,18 @@ return [
         'confirm' => 'Are you sure you want to perform this action?',
     ],
 
+    'bulk_actions' => [
+        'delete' => 'Bulk Delete',
+        'export' => 'Bulk Export',
+        'update' => 'Bulk Update',
+        'confirm' => 'Are you sure you want to perform this action on the selected items?',
+        'select_all' => 'Select All',
+        'deselect_all' => 'Deselect All',
+        'selected_count' => ':count item(s) selected',
+        'no_items_selected' => 'No items selected',
+        'clear_selection' => 'Clear Selection',
+    ],
+
     'filters' => [
         'select' => [
             'placeholder' => 'Select an option',

--- a/resources/js/datatables.js
+++ b/resources/js/datatables.js
@@ -56,3 +56,88 @@ $(document).on('click', '.datatable-action[method]:not([method="get"])', (event)
         callback();
     }
 });
+
+// Handle bulk action click
+$(document).on('click', '.datatable-bulk-action[method]:not([method="get"])', (event) => {
+    event.preventDefault();
+
+    // Get the action element
+    const $action = $(event.target).closest('.datatable-bulk-action');
+    
+    // Get the selected items from the Livewire component
+    const $datatableComponent = $action.closest('.datatable');
+    const livewireComponent = Livewire.find($datatableComponent.attr('wire:id'));
+    const selectedItems = livewireComponent.get('selected');
+
+    // Check if items are selected
+    if (!selectedItems || selectedItems.length === 0) {
+        alert('No items selected');
+        return;
+    }
+
+    // Check minimum selection
+    const minSelection = parseInt($action.attr('min-selection')) || 1;
+    if (selectedItems.length < minSelection) {
+        alert(`Please select at least ${minSelection} item(s)`);
+        return;
+    }
+
+    // Check maximum selection
+    const maxSelection = parseInt($action.attr('max-selection'));
+    if (maxSelection && selectedItems.length > maxSelection) {
+        alert(`Please select no more than ${maxSelection} item(s)`);
+        return;
+    }
+
+    // Define the callback function
+    const callback = function () {
+        const $form = $(`<form action="${$action.attr('href')}" method="POST" disable-validation></form>`);
+
+        // Spoof the form method
+        $form.append(`<input type="hidden" name="_method" value="${$action.attr('method')}">`);
+        $form.append(`<input type="hidden" name="_token" value="${$action.attr('token')}">`);
+
+        // Add selected items
+        selectedItems.forEach((item) => {
+            $form.append(`<input type="hidden" name="selected[]" value="${item}">`);
+        });
+
+        // Get request body
+        const requestBodyAttr = $action.attr('request-body');
+        if (requestBodyAttr) {
+            let body = JSON.parse(atob(requestBodyAttr));
+
+            // Append request body to the form
+            if (body && typeof body === 'object') {
+                Object.entries(body).forEach(([key, value]) => {
+                    if (Array.isArray(value)) {
+                        value.forEach((item) => {
+                            $form.append(`<input type="hidden" name="${key}[]" value="${item}">`);
+                        });
+                    } else {
+                        $form.append(`<input type="hidden" name="${key}" value="${value}">`);
+                    }
+                });
+            }
+        }
+
+        $form.appendTo('body').submit();
+    };
+
+    // Early return if no confirmation is required
+    if ($action.hasAttr('confirm') === false) {
+        return callback();
+    }
+
+    // Use warnBeforeAction if available
+    if (typeof warnBeforeAction !== 'undefined') {
+        return warnBeforeAction(callback, { 
+            content: $action.attr('confirm').replace(':count', selectedItems.length)
+        });
+    }
+
+    // Fallback to native confirm
+    if (confirm($action.attr('confirm').replace(':count', selectedItems.length))) {
+        callback();
+    }
+});

--- a/resources/views/datatable.blade.php
+++ b/resources/views/datatable.blade.php
@@ -38,6 +38,8 @@
         </div>
     @endif
 
+    @include('datatables::partials.bulk-actions-bar')
+
     @include('datatables::partials.table')
 
     <div class="card-footer">

--- a/resources/views/partials/bulk-action.blade.php
+++ b/resources/views/partials/bulk-action.blade.php
@@ -1,0 +1,13 @@
+@props(['bulkAction'])
+
+<button type="button" {{ $bulkAction->buildAttributes() }}>
+    @if ($bulkAction->icon)
+        <span>
+            <i @class([$bulkAction->icon, 'me-2' => $bulkAction->label])></i>
+        </span>
+    @endif
+
+    @if ($bulkAction->label)
+        <span>{{ $bulkAction->label }}</span>
+    @endif
+</button> 

--- a/resources/views/partials/bulk-actions-bar.blade.php
+++ b/resources/views/partials/bulk-actions-bar.blade.php
@@ -1,0 +1,32 @@
+@if ($bulkActionable)
+    <div class="card-body d-flex align-items-center gap-2" 
+         x-show="$wire.selected.length > 0" 
+         x-cloak
+         style="background-color: var(--tblr-bg-surface-secondary);">
+        
+        <div class="me-auto">
+            <span class="fw-medium">
+                <span x-text="$wire.selected.length"></span>
+                <span>{{ str_replace(':count', '', __('datatables::datatable.bulk_actions.selected_count')) }}</span>
+            </span>
+        </div>
+
+        <div class="d-flex gap-1">
+            @foreach ($bulkActions as $bulkAction)
+                @if ($bulkAction->shouldRender())
+                    @include('datatables::partials.bulk-action', [
+                        'bulkAction' => $bulkAction,
+                    ])
+                @endif
+            @endforeach
+        </div>
+
+        <button type="button" 
+                class="btn btn-outline-secondary btn-sm"
+                wire:click="clearSelection"
+                title="{{ __('datatables::datatable.bulk_actions.clear_selection') }}">
+            <i class="fas fa-times"></i>
+            {{ __('datatables::datatable.bulk_actions.clear_selection') }}
+        </button>
+    </div>
+@endif 

--- a/resources/views/partials/table.blade.php
+++ b/resources/views/partials/table.blade.php
@@ -6,6 +6,18 @@
         @if ($rows->isEmpty() === false)
             <thead @class(['sticky-top' => $stickyHeader])>
                 <tr>
+                    @if ($bulkActionable)
+                        <th class="w-1">
+                            <div class="form-check">
+                                <input type="checkbox" 
+                                       class="form-check-input" 
+                                       wire:model.live="selectAll"
+                                       wire:click="toggleSelectAll"
+                                       title="{{ $selectAll ? __('datatables::datatable.bulk_actions.deselect_all') : __('datatables::datatable.bulk_actions.select_all') }}">
+                            </div>
+                        </th>
+                    @endif
+
                     @foreach ($columns as $column)
                         <th @class(['fixed-' . $column->fixedDirection => $column->fixed])>
                             @if ($column->sortable && $column->name)
@@ -41,6 +53,18 @@
         <tbody wire:loading.class="opacity-50">
             @forelse($rows as $row)
                 <tr>
+                    @if ($bulkActionable)
+                        <td class="datatable-cell">
+                            <div class="form-check">
+                                <input type="checkbox" 
+                                       class="form-check-input" 
+                                       value="{{ $row->getKey() }}"
+                                       wire:model.live="selected"
+                                       wire:click="toggleSelect({{ $row->getKey() }})">
+                            </div>
+                        </td>
+                    @endif
+
                     @foreach ($columns as $column)
                         <td {{ $column->buildAttributes($row) }}>
                             {!! $column->get($row) !!}

--- a/src/Actions/BulkAction.php
+++ b/src/Actions/BulkAction.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace Redot\Datatables\Actions;
+
+use Closure;
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+use Redot\Datatables\Traits\BuildAttributes;
+
+class BulkAction
+{
+    use BuildAttributes;
+    use Macroable;
+
+    /**
+     * The label of the bulk action.
+     */
+    public ?string $label = null;
+
+    /**
+     * The icon of the bulk action.
+     */
+    public ?string $icon = null;
+
+    /**
+     * The route of the bulk action.
+     */
+    public ?string $route = null;
+
+    /**
+     * The href of the bulk action.
+     */
+    public string|Closure|null $href = null;
+
+    /**
+     * The route parameters of the bulk action.
+     */
+    public array $parameters = [];
+
+    /**
+     * Form data to be sent with the bulk action.
+     */
+    public array $body = [];
+
+    /**
+     * The method of the bulk action.
+     */
+    public string $method = 'post';
+
+    /**
+     * Determine if the bulk action is visible.
+     */
+    public bool $visible = true;
+
+    /**
+     * The condition callback of the bulk action.
+     */
+    public ?Closure $condition = null;
+
+    /**
+     * Determine if the bulk action should be opened in a new tab.
+     */
+    public bool $newTab = false;
+
+    /**
+     * Determine if the bulk action is confirmable.
+     */
+    public bool $confirmable = false;
+
+    /**
+     * Confirm message for the bulk action.
+     */
+    public ?string $confirmMessage = null;
+
+    /**
+     * Minimum number of selected items required.
+     */
+    public int $minSelection = 1;
+
+    /**
+     * Maximum number of selected items allowed.
+     */
+    public ?int $maxSelection = null;
+
+    /**
+     * Button variant/style class.
+     */
+    public string $variant = 'outline-primary';
+
+    /**
+     * Create a new bulk action instance.
+     */
+    public function __construct(?string $label = null, ?string $icon = null)
+    {
+        if ($label) {
+            $this->label($label);
+        }
+
+        if ($icon) {
+            $this->icon($icon);
+        }
+    }
+
+    /**
+     * Create a new bulk action instance.
+     */
+    public static function make(?string $label = null, ?string $icon = null): BulkAction
+    {
+        return new static($label, $icon);
+    }
+
+    /**
+     * Create a new bulk delete action instance.
+     */
+    public static function delete(?string $route = null, array $parameters = []): BulkAction
+    {
+        $action = static::make(__('datatables::datatable.bulk_actions.delete'), 'fas fa-trash-alt')
+            ->method('delete')
+            ->variant('outline-danger')
+            ->confirmable();
+
+        if ($route) {
+            $action->route($route, $parameters);
+        }
+
+        return $action;
+    }
+
+    /**
+     * Create a new bulk export action instance.
+     */
+    public static function export(?string $route = null, array $parameters = []): BulkAction
+    {
+        $action = static::make(__('datatables::datatable.bulk_actions.export'), 'fas fa-file-export')
+            ->variant('outline-success');
+
+        if ($route) {
+            $action->route($route, $parameters);
+        }
+
+        return $action;
+    }
+
+    /**
+     * Create a new bulk update action instance.
+     */
+    public static function update(?string $route = null, array $parameters = []): BulkAction
+    {
+        $action = static::make(__('datatables::datatable.bulk_actions.update'), 'fas fa-edit')
+            ->method('patch')
+            ->variant('outline-warning');
+
+        if ($route) {
+            $action->route($route, $parameters);
+        }
+
+        return $action;
+    }
+
+    /**
+     * Set the label of the bulk action.
+     */
+    public function label(string $label): self
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    /**
+     * Set the icon of the bulk action.
+     */
+    public function icon(string $icon): self
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    /**
+     * Set the route of the bulk action.
+     */
+    public function route(string $route, array $parameters = [], ?string $method = null): self
+    {
+        $this->route = $route;
+        $this->parameters = array_merge($this->parameters, $parameters);
+
+        if ($method) {
+            $this->method($method);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the href of the bulk action.
+     */
+    public function href(string|Closure $href): self
+    {
+        $this->href = $href;
+
+        return $this;
+    }
+
+    /**
+     * Set the parameters of the bulk action.
+     */
+    public function parameters(array $parameters): self
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+
+    /**
+     * Set the body of the form request.
+     */
+    public function body(array $body = []): self
+    {
+        $this->body = array_merge($this->body, $body);
+
+        return $this;
+    }
+
+    /**
+     * Set the method of the bulk action.
+     */
+    public function method(string $method): self
+    {
+        $allowedMethods = ['get', 'post', 'put', 'patch', 'delete'];
+        $method = strtolower($method);
+
+        if (! in_array($method, $allowedMethods)) {
+            throw new InvalidArgumentException(sprintf('Invalid method provided "%s", allowed methods are: %s.', $method, implode(', ', $allowedMethods)));
+        }
+
+        $this->method = $method;
+
+        return $this;
+    }
+
+    /**
+     * Set the visibility of the bulk action.
+     */
+    public function visible(bool $visible = true): BulkAction
+    {
+        $this->visible = $visible;
+
+        return $this;
+    }
+
+    /**
+     * Set the visibility of the bulk action to hidden.
+     */
+    public function hidden(bool $hidden = true): BulkAction
+    {
+        return $this->visible(! $hidden);
+    }
+
+    /**
+     * Set the condition callback of the bulk action.
+     */
+    public function condition(Closure $condition): self
+    {
+        $this->condition = $condition;
+
+        return $this;
+    }
+
+    /**
+     * Set the bulk action to be opened in a new tab.
+     */
+    public function newTab(bool $newTab = true): self
+    {
+        $this->newTab = $newTab;
+
+        return $this;
+    }
+
+    /**
+     * Set the bulk action to be confirmable.
+     */
+    public function confirmable(bool $confirmable = true, ?string $message = null): self
+    {
+        $this->confirmable = $confirmable;
+
+        if ($message) {
+            $this->confirmMessage($message);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the confirm message for the bulk action.
+     */
+    public function confirmMessage(string $confirmMessage): self
+    {
+        $this->confirmMessage = $confirmMessage;
+
+        return $this;
+    }
+
+    /**
+     * Set the minimum selection required.
+     */
+    public function minSelection(int $minSelection): self
+    {
+        $this->minSelection = $minSelection;
+
+        return $this;
+    }
+
+    /**
+     * Set the maximum selection allowed.
+     */
+    public function maxSelection(?int $maxSelection): self
+    {
+        $this->maxSelection = $maxSelection;
+
+        return $this;
+    }
+
+    /**
+     * Set the button variant.
+     */
+    public function variant(string $variant): self
+    {
+        $this->variant = $variant;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the bulk action should be rendered.
+     */
+    public function shouldRender(): bool
+    {
+        return $this->visible && ($this->condition ? call_user_func($this->condition) : true);
+    }
+
+    /**
+     * Prepare the attributes before building.
+     */
+    protected function prepareAttributes(): void
+    {
+        if ($this->confirmable && $this->method === 'get') {
+            throw new InvalidArgumentException('Confirmable bulk actions must have a method other than "get".');
+        }
+
+        if ($this->route) {
+            $parameters = $this->parameters;
+
+            $body = $this->body;
+
+            // If the method is GET, we need to append the body to query string
+            if ($this->method === 'get') {
+                $parameters = array_merge($parameters, $body);
+            } else {
+                $this->attribute('request-body', base64_encode(json_encode($body, JSON_UNESCAPED_UNICODE)));
+            }
+
+            $this->attributes([
+                'href' => route($this->route, $parameters),
+                'method' => $this->method,
+                'token' => csrf_token(),
+            ]);
+        }
+
+        if ($this->href) {
+            $this->attribute('href', is_callable($this->href) ? call_user_func($this->href) : $this->href);
+        }
+
+        if ($this->newTab) {
+            $this->attribute('target', '_blank');
+        }
+
+        if ($this->confirmable) {
+            $this->attribute('confirm', $this->confirmMessage ?? __('datatables::datatable.bulk_actions.confirm'));
+        }
+
+        if ($this->minSelection > 1) {
+            $this->attribute('min-selection', $this->minSelection);
+        }
+
+        if ($this->maxSelection) {
+            $this->attribute('max-selection', $this->maxSelection);
+        }
+
+        $this->attributes([
+            'title' => $this->label,
+            'data-bs-toggle' => 'tooltip',
+            'data-bs-placement' => 'bottom',
+        ]);
+
+        // Append the class for the bulk action
+        $this->class(['datatable-bulk-action', 'btn', 'btn-' . $this->variant]);
+    }
+} 


### PR DESCRIPTION
This pull request introduces a comprehensive bulk actions feature for datatables, enabling users to perform operations on multiple selected rows simultaneously. The changes include the addition of a new `UserDatatable` class, updates to the frontend and backend to support bulk actions, and enhancements to localization files for internationalization support.

### Backend and Datatable Enhancements:
* Created the `UserDatatable` class with support for bulk actions such as delete, export, activate, and custom actions. It includes constraints like minimum and maximum selection limits and conditional visibility. (`Examples/UserDatatable.php`, [Examples/UserDatatable.phpR1-R102](diffhunk://#diff-8a7fec6bb3d89eeeeaee6dce5e66e3f8082f7c0433a19de7ffe6c415084fbea0R1-R102))
* Updated localization files to include translations for bulk action labels and messages in both English and Arabic. (`lang/en/datatable.php`, [[1]](diffhunk://#diff-9fd4e289da00132f342b26e2a1cbc6cbc4b14b0e2e41760abb63dc3b93a50d56R44-R55); `lang/ar/datatable.php`, [[2]](diffhunk://#diff-e871753bf64907165598b88a2e7276de3d4a2481d149da7c9e7fbb395c0e813fR44-R55)

### Documentation Updates:
* Added a new `docs/bulk-actions.md` file detailing how to define and configure bulk actions, integrate them with the frontend, and handle them in controllers. It includes examples of routes, controllers, and internationalization.

### Frontend Integration:
* Enhanced the JavaScript logic in `resources/js/datatables.js` to handle bulk action clicks, validate selection constraints, and submit requests for selected items.
* Updated `resources/views/datatable.blade.php` to include a bulk actions bar for selected items and integrated it with the datatable layout.

### UI Improvements:
* Added new partial views for the bulk actions bar and individual bulk action buttons, ensuring a clean and reusable UI. (`resources/views/partials/bulk-actions-bar.blade.php`, [[1]](diffhunk://#diff-7a93e656c60410ec544beb8525b2e943925418be35240e2973ed9b2c89e9104bR1-R32); `resources/views/partials/bulk-action.blade.php`, [[2]](diffhunk://#diff-a40a621f5b8a6189f1d6b5a6b09f90de4bcbf14bbc5a4de65ecaff3bbf0975aaR1-R13)
* Modified the table view to include checkboxes for row selection and a "select all" checkbox in the header for bulk selection. (`resources/views/partials/table.blade.php`, [[1]](diffhunk://#diff-3cd6e5a421ac54ef4c131ccac5810582900d5ad9dfb1b68df1529d2361f78facR9-R20) [[2]](diffhunk://#diff-3cd6e5a421ac54ef4c131ccac5810582900d5ad9dfb1b68df1529d2361f78facR56-R67)